### PR TITLE
Empty reports folder fix.

### DIFF
--- a/src/main/kotlin/com/github/platan/tests_execution_chart/config/Format.kt
+++ b/src/main/kotlin/com/github/platan/tests_execution_chart/config/Format.kt
@@ -1,17 +1,17 @@
 package com.github.platan.tests_execution_chart.config
 
+import javax.inject.Inject
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.OutputDirectory
-import javax.inject.Inject
+import org.gradle.api.tasks.Internal
 
 abstract class Format @Inject constructor(objectFactory: ObjectFactory, name: String) {
 
     @get:Input
     val enabled: Property<Boolean> = objectFactory.property(Boolean::class.java).convention(true)
 
-    @get:OutputDirectory
+    @Internal
     val outputLocation: Property<String> =
         objectFactory.property(String::class.java).convention("reports/tests-execution/$name")
 }


### PR DESCRIPTION
Changed OutputDirectory annotation for preventing empty reports folder on project root.